### PR TITLE
Recaser trainer updated to support IRSTLM as well.

### DIFF
--- a/scripts/recaser/train-recaser.perl
+++ b/scripts/recaser/train-recaser.perl
@@ -51,12 +51,10 @@ sub truecase {
 sub train_lm {
     print STDERR "(2) Train language model on cased data @ ".`date`;
     my $cmd = "";
-    if (uc $LM eq "IRSTLM")
-    {
+    if (uc $LM eq "IRSTLM") {
         $cmd = "$BUILD_LM -t /tmp -i $CORPUS -n 3 -o $DIR/cased.irstlm.gz";
     }
-    else
-    {
+    else {
         $LM = "SRILM";
         $cmd = "$NGRAM_COUNT -text $CORPUS -lm $DIR/cased.srilm.gz -interpolate -kndiscount";
     }
@@ -103,12 +101,10 @@ sub train_recase_model {
     $first = 4 if $first < 4;
     print STDERR "\n(4) Training recasing model @ ".`date`;
     my $cmd = "$TRAIN_SCRIPT --root-dir $DIR --model-dir $DIR --first-step $first --alignment a --corpus $DIR/aligned --f lowercased --e cased --max-phrase-length $MAX_LEN";
-    if (uc $LM eq "IRSTLM")
-    {
+    if (uc $LM eq "IRSTLM") {
         $cmd .= " --lm 0:3:$DIR/cased.irstlm.gz:1";
     }
-    else
-    {
+    else {
         $cmd .= " --lm 0:3:$DIR/cased.srilm.gz:0";
     }
     $cmd .= " -scripts-root-dir $SCRIPTS_ROOT_DIR" if $SCRIPTS_ROOT_DIR;


### PR DESCRIPTION
A per discussions on the mailing list, everyone who wants to use IRSTLM instead of SRILM for training the recaser was modifying train-recaser.perl. Rather than always doing this (and probably see other messages about this on the list), I thought it might be worth updating the script.

Note that by default, the script will still use SRILM, which prevent from breakage any existing script calling the current version of train-recaser.perl.
To use IRSTLM instead of SRILM, only adding "-lm irstlm" on the command line is enough.
In case build-lm.sh is not in $PATH, there is also a new option -build-lm which allows one to specify the given path of the script to use (with build-lm.sh command line syntax).

If anyone wants to add other language models (for instance KenLM would be great, after all default in Moses!), that will be easy using the -lm option.
Thanks.
