### PR TITLE
Recaser training script improved with --help output and better error handling

### DIFF
--- a/scripts/recaser/train-recaser.perl
+++ b/scripts/recaser/train-recaser.perl
@@ -8,7 +8,7 @@ binmode(STDIN, ":utf8");
 binmode(STDOUT, ":utf8");
 
 # apply switches
-my ($DIR,$CORPUS,$SCRIPTS_ROOT_DIR,$CONFIG);
+my ($DIR,$CORPUS,$SCRIPTS_ROOT_DIR,$CONFIG,$HELP,$ERROR);
 my $LM = "SRILM"; # SRILM is default.
 my $BUILD_LM = "build-lm.sh";
 my $NGRAM_COUNT = "ngram-count";
@@ -16,8 +16,6 @@ my $TRAIN_SCRIPT = "train-factored-phrase-model.perl";
 my $MAX_LEN = 1;
 my $FIRST_STEP = 1;
 my $LAST_STEP = 11;
-my $HELP = 0;
-my $ERROR = 0;
 $ERROR = "training Aborted."
     unless &GetOptions('first-step=i' => \$FIRST_STEP,
                        'last-step=i' => \$LAST_STEP,
@@ -33,8 +31,8 @@ $ERROR = "training Aborted."
                        'help' => \$HELP);
 
 # check and set default to unset parameters
-$ERROR = "please specify working dir --dir" unless defined($DIR);
-$ERROR = "please specify --corpus" if !defined($CORPUS) 
+$ERROR = "please specify working dir --dir" unless defined($DIR) || defined($HELP);
+$ERROR = "please specify --corpus" if !defined($CORPUS) && !defined($HELP) 
                                   && $FIRST_STEP <= 2 && $LAST_STEP >= 1;
 
 if ($HELP || $ERROR) {


### PR DESCRIPTION
2 ameliorations on train-recaser.perl:

1/ --help output added, with all option descriptions and also all steps involved in training (so that it means something to use --first-step and --last-step.
This implies also better handling when mandatory options are not set (usage is shown as well in these cases).

2/ The current script has the bad habit to continue running no matter what, even when a major step implying a third party script, failed (for whatever reason). This makes it very hard to debug when there is a problem.
I made so that after the 2 calls are made (during language model training, then recaser model training), the script ends with a relevant error message displayed, for facilitated investigation.
