### PR TITLE
Fix to the bjam script which failed me with an error

### DIFF
--- a/moses/src/LM/Jamfile
+++ b/moses/src/LM/Jamfile
@@ -51,7 +51,7 @@ lib LM : Base.cpp Factory.o Implementation.cpp Joint.cpp Ken.cpp MultiFactor.cpp
 
 #Huge kludge to force building if different --with options are passed.  
 #Could have used features like <srilm>on but getting these to apply only to linking was ugly and it still didn't trigger an install (since the install path doesn't encode features).  
-path-constant LM-LOG : bin/lm.log ;
+path-constant LM-LOG : ../../../bin/lm.log ;
 #Is there no other way to read a file with bjam?  
 local previous = none ;
 if [ path.exists $(LM-LOG) ] {


### PR DESCRIPTION
The bjam script would return with:
«
failed to write output file '/path/to/src/moses/src/LM/bin/lm.log'!
»
Seems either directory bin/ is missing under moses/src/LM/ and needs to be created, or this was not the expected target directory. Seeing a bin/ at the root, and a config.log inside, I went with the assumption that lm.log was supposed to go there as well.
