### PR TITLE
Fixes to make gzFile work with zlib-1.2.6

### DIFF
--- a/scripts/training/lexical-reordering/reordering_classes.cpp
+++ b/scripts/training/lexical-reordering/reordering_classes.cpp
@@ -380,10 +380,10 @@ void Model::zipFile()
   char inbuffer[128];
   int num_read;
   while ((num_read = fread(inbuffer, 1, sizeof(inbuffer), file)) > 0) {
-    gzwrite(gzfile, inbuffer, num_read);
+    gzwrite((gzFile)gzfile, inbuffer, num_read);
   }
   fclose(file);
-  gzclose(gzfile);
+  gzclose((gzFile)gzfile);
 
   //Remove the unzipped file
   remove(filename.c_str());

--- a/util/file_piece.cc
+++ b/util/file_piece.cc
@@ -31,7 +31,7 @@ ParseNumberException::ParseNumberException(StringPiece value) throw() {
 GZException::GZException(void *file) {
 #ifdef HAVE_ZLIB
   int num;
-  *this << gzerror(file, &num) << " from zlib";
+  *this << gzerror((gzFile)file, &num) << " from zlib";
 #endif // HAVE_ZLIB
 }
 
@@ -56,7 +56,7 @@ FilePiece::~FilePiece() {
     // zlib took ownership
     file_.release();
     int ret;
-    if (Z_OK != (ret = gzclose(gz_file_))) {
+    if (Z_OK != (ret = gzclose((gzFile)gz_file_))) {
       std::cerr << "could not close file " << file_name_ << " using zlib" << std::endl;
       abort();
     }
@@ -295,7 +295,7 @@ void FilePiece::ReadShift() {
 
   ssize_t read_return;
 #ifdef HAVE_ZLIB
-  read_return = gzread(gz_file_, static_cast<char*>(data_.get()) + already_read, default_map_size_ - already_read);
+  read_return = gzread((gzFile)gz_file_, static_cast<char*>(data_.get()) + already_read, default_map_size_ - already_read);
   if (read_return == -1) throw GZException(gz_file_);
   if (total_size_ != kBadSize) {
     // Just get the position, don't actually seek.  Apparently this is how you do it. . . 


### PR DESCRIPTION
Implicit casting from `FILE*` to `gzFile_s*` does not work anymore since `gzFile` has been changed from `void *` to `gzFile_s *` in zlib-1.2.6.

```
-typedef voidp gzFile;       /* opaque gzip file descriptor */
+typedef struct gzFile_s *gzFile;    /* semi-opaque gzip file descriptor */
```
