### PR TITLE
removing deprecated function at moses/src/StaticData.cpp

### DIFF
--- a/moses/src/StaticData.cpp
+++ b/moses/src/StaticData.cpp
@@ -1355,7 +1355,7 @@ void StaticData::SetExecPath(const std::string &path)
   full_path = fs::system_complete( fs::path( path ) );
     
   //Without file name
-  m_binPath = full_path.parent_path().native_file_string();
+  m_binPath = full_path.parent_path().c_str();
   cerr << m_binPath << endl;
 
 }


### PR DESCRIPTION
native_file_string() is deprecated at boost 1.48.0.2
