### PR TITLE
Adding time information to EMS output files

### DIFF
--- a/scripts/ems/experiment.perl
+++ b/scripts/ems/experiment.perl
@@ -2690,7 +2690,7 @@ sub create_step {
     print STEP "cd $dir\n";
     print STEP "echo 'starting at '`date`' on '`hostname`\n";
     print STEP "mkdir -p $dir/$subdir\n\n";
-    print STEP "$cmd\n\n";
+    print STEP "/usr/bin/time --output=$file.TIME -p $cmd\n\n";
     print STEP "echo 'finished at '`date`\n";
     print STEP "touch $file.DONE\n";
     close(STEP);


### PR DESCRIPTION
When doing EMS experiment, I needed to know how much time particular steps take.

Altough I can use .OUTPUT files for that, it is a little cumbersome, so I added /usr/bin/time to take care of that, with output saved to .TIME files.

If you think this is useful you might add that to the main repo.
