### PR TITLE
Fixes compilation error using libboost_1_50

### DIFF
--- a/moses-cmd/Main.cpp
+++ b/moses-cmd/Main.cpp
@@ -197,7 +197,7 @@ public:
 	string nbestFile = staticData.GetNBestFilePath();
 	if ( ! nbestFile.empty() && nbestFile!="-" && !boost::starts_with(nbestFile,"/dev/stdout") ) {
 	  boost::filesystem::path nbestPath(nbestFile);
-	  //hypergraphDir = nbestPath.parent_path().filename();
+	  hypergraphDir = nbestPath.parent_path().filename().native();
 	} else {
 	  stringstream hypergraphDirName;
 	  hypergraphDirName << boost::filesystem::current_path() << "/hypergraph";
@@ -214,7 +214,6 @@ public:
       } else if ( ! boost::filesystem::is_directory(hypergraphDir) ) {
 	TRACE_ERR("Cannot output hypergraphs to " << hypergraphDir << " because that path exists, but is not a directory" << std::endl);
       } else {
-	
 	stringstream fileName;
 	fileName << hypergraphDir << "/" << m_lineNumber;
 	if ( appendSuffix ) {


### PR DESCRIPTION
Problem spotted in https://github.com/moses-smt/mosesdecoder/issues/32 
fixed.

According to the Boost doc, nbestPath.parent_path().filename() 
returns a path object, to get the correspondent std::string 
representation, one must call one of the methods listed in:
http://www.boost.org/doc/libs/1_53_0/libs/filesystem/doc/reference.html#path-native-format-observers

native() is supposed to return the path in the specific OS
path format (using backslashes for Windows). Anyway, since we 
are considering only the filename here, the result is the same.
