### PR TITLE
Fixed crash in interpolation for small lambdas

### DIFF
--- a/scripts/ems/support/interpolate-lm.perl
+++ b/scripts/ems/support/interpolate-lm.perl
@@ -135,7 +135,7 @@ sub interpolate {
   die "Failed to mix models: $mixerr" if $mixexitcode != 0;
   my $mix = $mixout;
   `rm $tmp/iplm.$$.*`;
-  $mix =~ /best lambda \(([\d\. ]+)\)/ || die("ERROR: computing lambdas failed: $mix");
+  $mix =~ /best lambda \(([\d\. e-]+)\)/ || die("ERROR: computing lambdas failed: $mix");
   my @LAMBDA = split(/ /,$1);
 
   # create new language model


### PR DESCRIPTION
The EMS crashed when interpolating language models when the ideal lambdas included numbers so small that they required scientific notation (eg: 1.332e-07). This patch adds "e" and "-" to the acceptable numbers to fix this problem
