### PR TITLE
Fixed bug in tokenizer.perl where comma separated lists of single characters aren't handled correctly, updated Russian NBP list

### DIFF
--- a/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.ru
+++ b/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.ru
@@ -1,4 +1,38 @@
-TBD: Russian uppercase alphabet [А-Я]
+# added Cyrillic uppercase letters [А-Я]
+# removed 000D carriage return (this is not removed by chomp in tokenizer.perl, and prevents recognition of the prefixes)
+# edited by Kate Young (nspaceanalysis@earthlink.net) 21 May 2013
+А
+Б
+В
+Г
+Д
+Е
+Ж
+З
+И
+Й
+К
+Л
+М
+Н
+О
+П
+Р
+С
+Т
+У
+Ф
+Х
+Ц
+Ч
+Ш
+Щ
+Ъ
+Ы
+Ь
+Э
+Ю
+Я
 A
 B
 C

--- a/scripts/tokenizer/tokenizer.perl
+++ b/scripts/tokenizer/tokenizer.perl
@@ -230,10 +230,19 @@ sub tokenize
     }
 
     # seperate out "," except if within numbers (5,300)
-    $text =~ s/([^\p{IsN}])[,]([^\p{IsN}])/$1 , $2/g;
+    #$text =~ s/([^\p{IsN}])[,]([^\p{IsN}])/$1 , $2/g;
+
+    # separate out "," except if within numbers (5,300)
+    # previous "global" application skips some:  A,B,C,D,E > A , B,C , D,E
+    # first application uses up B so rule can't see B,C
+    # two-step version here may create extra spaces but these are removed later
+    # will also space digit,letter or letter,digit forms (redundant with next section)
+    $text =~ s/([^\p{IsN}])[,]/$1 , /g;
+    $text =~ s/[,]([^\p{IsN}])/ , $1/g;
+
     # separate , pre and post number
-    $text =~ s/([\p{IsN}])[,]([^\p{IsN}])/$1 , $2/g;
-    $text =~ s/([^\p{IsN}])[,]([\p{IsN}])/$1 , $2/g;
+    #$text =~ s/([\p{IsN}])[,]([^\p{IsN}])/$1 , $2/g;
+    #$text =~ s/([^\p{IsN}])[,]([\p{IsN}])/$1 , $2/g;
 	      
     # turn `into '
     $text =~ s/\`/\'/g;


### PR DESCRIPTION
Committing fixes from a colleague not on GitHub - minor tokenizer fix and updated Russian nonbreaking prefix list

Fixed bug in tokenizer.perl where comma separated lists of single characters aren't handled correctly

input> A,B,C,D,E,F

yielded> A, B,C , D,E , F

now yields> A, B, C, D, E, F

Updated Russian nonbreaking prefixes list with capital letters
