### PR TITLE
Fix mert-moses.pl portability

### DIFF
--- a/scripts/training/mert-moses.pl
+++ b/scripts/training/mert-moses.pl
@@ -1647,7 +1647,7 @@ sub create_extractor_script() {
 
   open my $out, '>', $script_path
       or die "Couldn't open $script_path for writing: $!\n";
-  print $out "#!/bin/bash\n";
+  print $out "#!/bin/sh\n";
   print $out "cd $outdir\n";
   print $out "$cmd\n";
   close $out;


### PR DESCRIPTION
bash isn't necessarily at /bin/bash (e.g. FreeBSD).
Besides, the script is simple enough to run with regular /bin/sh
