### PR TITLE
Update train-model.perl

### DIFF
--- a/scripts/training/train-model.perl
+++ b/scripts/training/train-model.perl
@@ -1120,6 +1120,7 @@ sub run_single_giza {
 	 m2 => 0 , 
 	 m3 => 3 , 
 	 m4 => 3 , 
+	 hmmiterations => 0 ,
 	 o => "giza" ,
 	 nodumps => 1 ,
 	 onlyaldumps => 1 ,
@@ -1141,7 +1142,6 @@ sub run_single_giza {
     if ($_HMM_ALIGN) {
        $GizaDefaultOptions{m3} = 0;
        $GizaDefaultOptions{m4} = 0;
-       $GizaDefaultOptions{hmmiterations} = 5;
        $GizaDefaultOptions{hmmdumpfrequency} = 5;
        $GizaDefaultOptions{nodumps} = 0;
     }


### PR DESCRIPTION
The default hmm iterations of GIZA++ is 5. Even though the "hmm-align" option is not set. The hmm align is also activated when using the training script.
