### PR TITLE
DistortionFunctionScorer dyn_cast removed in FF.

### DIFF
--- a/moses/BitmapContainer.cpp
+++ b/moses/BitmapContainer.cpp
@@ -56,19 +56,15 @@ public:
     m_transOptRange(transOptRange) {
     m_totalWeightDistortion = 0;
     const StaticData &staticData = StaticData::Instance();
-    const std::vector<FeatureFunction*> &ffs = FeatureFunction::GetFeatureFunctions();
-    std::vector<FeatureFunction*>::const_iterator iter;
-    for (iter = ffs.begin(); iter != ffs.end(); ++iter) {
-      const FeatureFunction *ff = *iter;
 
-      const DistortionScoreProducer *model = dynamic_cast<const DistortionScoreProducer*>(ff);
-      if (model) {
-        float weight =staticData.GetAllWeights().GetScoreForProducer(model);
-        m_totalWeightDistortion += weight;
-      }
+    const std::vector<const DistortionScoreProducer*> &ffs = FeatureFunction::GetDistortionFeatureFunctions();
+    std::vector<const DistortionScoreProducer*>::const_iterator iter;
+    for (iter = ffs.begin(); iter != ffs.end(); ++iter) {
+      const DistortionScoreProducer *ff = *iter;
+
+      float weight =staticData.GetAllWeights().GetScoreForProducer(ff);
+      m_totalWeightDistortion += weight;
     }
-  
-      
   }
 
   const WordsRange* m_transOptRange;

--- a/moses/FF/FeatureFunction.cpp
+++ b/moses/FF/FeatureFunction.cpp
@@ -7,6 +7,7 @@
 #include "moses/Manager.h"
 #include "moses/TranslationOption.h"
 #include "moses/Util.h"
+#include "moses/FF/DistortionScoreProducer.h"
 
 using namespace std;
 
@@ -16,6 +17,7 @@ namespace Moses
 multiset<string> FeatureFunction::description_counts;
 
 std::vector<FeatureFunction*> FeatureFunction::s_staticColl;
+std::vector<const DistortionScoreProducer*> FeatureFunction::s_staticCollDistortion;
 
 FeatureFunction &FeatureFunction::FindFeatureFunction(const std::string& name)
 {
@@ -67,6 +69,10 @@ Initialize(const std::string &line)
 
   ScoreComponentCollection::RegisterScoreProducer(this);
   s_staticColl.push_back(this);
+
+  const DistortionScoreProducer *distortion = dynamic_cast<const DistortionScoreProducer*>(this);
+  if(distortion)
+    s_staticCollDistortion.push_back (distortion);
 }
 
 FeatureFunction::~FeatureFunction() {}

--- a/moses/FF/FeatureFunction.h
+++ b/moses/FF/FeatureFunction.h
@@ -22,6 +22,7 @@ class WordsRange;
 class FactorMask;
 class InputPath;
 class StackVec;
+class DistortionScoreProducer;
 
 /** base class for all feature functions.
  */
@@ -30,6 +31,7 @@ class FeatureFunction
 protected:
   /**< all the score producers in this run */
   static std::vector<FeatureFunction*> s_staticColl;
+  static std::vector<const DistortionScoreProducer*> s_staticCollDistortion;
 
   std::string m_description, m_argLine;
   std::vector<std::vector<std::string> > m_args;
@@ -45,6 +47,11 @@ public:
   static const std::vector<FeatureFunction*>& GetFeatureFunctions() {
     return s_staticColl;
   }
+
+  static const std::vector<const DistortionScoreProducer*>& GetDistortionFeatureFunctions() {
+    return s_staticCollDistortion;
+  }
+
   static FeatureFunction &FindFeatureFunction(const std::string& name);
   static void Destroy();
 


### PR DESCRIPTION
Hello.

Following patch improves Moses performance, more more detail results, please visit:
http://marxin.github.io/posts/moses-performance-tuning/

Thanks,
Martin
