### PR TITLE
die if the forked extract exited with error

### DIFF
--- a/scripts/generic/extract-parallel.perl
+++ b/scripts/generic/extract-parallel.perl
@@ -149,9 +149,8 @@ for (my $i = 0; $i < $numParallel; ++$i)
     print "glueArg=$glueArg \n";
 
     my $cmd = "$extractCmd $TMPDIR/target.$numStr $TMPDIR/source.$numStr $TMPDIR/align.$numStr $TMPDIR/extract.$numStr $glueArg $otherExtractArgs $weightsCmd --SentenceOffset ".($i*$linesPerSplit)." 2>> /dev/stderr \n";
-    print STDERR $cmd;
-    `$cmd`;
 
+    safesystem($cmd) or die;
     exit();
   }
   else
@@ -163,6 +162,10 @@ for (my $i = 0; $i < $numParallel; ++$i)
 # wait for everything is finished
 foreach (@children) {
 	waitpid($_, 0);
+        if($? != 0) {
+                print STDERR "ERROR: Failed to execute: @_\n  $!\n";
+                exit(1);
+        }
 }
 
 # merge
@@ -323,5 +326,24 @@ sub NumStr($)
 	$numStr = $i;
     }
     return $numStr;
+}
+
+sub safesystem {
+  print STDERR "Executing: @_\n";
+  system(@_);
+  if ($? == -1) {
+      print STDERR "ERROR: Failed to execute: @_\n  $!\n";
+      exit(1);
+  }
+  elsif ($? & 127) {
+      printf STDERR "ERROR: Execution of: @_\n  died with signal %d, %s coredump\n",
+          ($? & 127),  ($? & 128) ? 'with' : 'without';
+      exit(1);
+  }
+  else {
+    my $exitcode = $? >> 8;
+    print STDERR "Exit code: $exitcode\n" if $exitcode;
+    return ! $exitcode;
+  }
 }
 


### PR DESCRIPTION
This makes the parent process stop at the actual error (e.g. if https://github.com/moses-smt/mosesdecoder/pull/110 were not fixed), instead of failing long afterwards due to more indirect errors.

Should we pass on bad exit codes from RunFork to those waitpids as well? It seems like the right thing to do, though I haven't done that yet since I figured someone who knows the code should chime in.