### PR TITLE
using mgiza without move/link files and keeping backward compatibility

### DIFF
--- a/scripts/training/train-model.perl
+++ b/scripts/training/train-model.perl
@@ -357,7 +357,9 @@ foreach my $step (@step_conf) {
 
 # supporting binaries from other packages
 my $MKCLS = "$_EXTERNAL_BINDIR/mkcls";
-my $MGIZA_MERGE_ALIGN = "$_EXTERNAL_BINDIR/merge_alignment.py";
+my $MGIZA_MERGE_ALIGN_IN_BIN = "$_EXTERNAL_BINDIR/merge_alignment.py";
+my $MGIZA_MERGE_ALIGN_IN_SCRIPTS = "$_EXTERNAL_BINDIR/../scripts/merge_alignment.py";
+my $MGIZA_MERGE_ALIGN;
 my $GIZA;
 my $SNT2COOC;
 
@@ -387,7 +389,13 @@ if ($STEPS[1] || $STEPS[2])
 		if (!defined($_MGIZA_CPUS)) {
 			$_MGIZA_CPUS=4;
 		}
-		die("ERROR: Cannot find $MGIZA_MERGE_ALIGN") unless (-x $MGIZA_MERGE_ALIGN);
+		if (-x $MGIZA_MERGE_ALIGN_IN_BIN) {
+			$MGIZA_MERGE_ALIGN = $MGIZA_MERGE_ALIGN_IN_BIN;
+		} elsif (-x $MGIZA_MERGE_ALIGN_IN_SCRIPTS) {
+			$MGIZA_MERGE_ALIGN = $MGIZA_MERGE_ALIGN_IN_SCRIPTS;
+		} else {
+			die("ERROR: Cannot find $MGIZA_MERGE_ALIGN_IN_BIN or $MGIZA_MERGE_ALIGN_IN_SCRIPTS");
+		}
 	}
 
 	# override


### PR DESCRIPTION
It is tree structure of mgiza executable files.
```
inst
├── bin
│   ├── d4norm
│   ├── hmmnorm
│   ├── mgiza
│   ├── mkcls
│   ├── plain2snt
│   ├── snt2cooc
│   ├── snt2coocrmp
│   ├── snt2plain
│   └── symal
├── lib
│   └── libmgiza.a
└── scripts
    ├── force-align-moses-old.sh
    ├── force-align-moses.sh
    ├── giza2bal.pl
    ├── merge_alignment.py
    ├── plain2snt-hasvcb.py
    ├── run.sh
    ├── snt2cooc.pl
    └── sntpostproc.py
```
`merge_alignment.py`  and `mgiza` are in different directories.
`merge_alignment.py` is in `scripts`, not in `bin`.
So detecting whether `merge_alignment.py` is in `bin` or `scripts`.