### PR TITLE
Fix 'Use of uninitialized value' error through explicit setting of 0s…

### DIFF
--- a/scripts/analysis/bootstrap-hypothesis-difference-significance.pl
+++ b/scripts/analysis/bootstrap-hypothesis-difference-significance.pl
@@ -313,6 +313,9 @@ sub preEvalHypoSnt {
 
 		#correct, total
 		for my $ngram (keys %$hypNgramCounts) {
+			if (!exists $refNgramCounts->{$ngram}) {
+				$refNgramCounts->{$ngram} = 0;
+			}
 			$coocUpd = min($hypNgramCounts->{$ngram}, $refNgramCounts->{$ngram});
 			$correctNgramCounts += $coocUpd;
 			$totalNgramCounts += $hypNgramCounts->{$ngram};
@@ -514,6 +517,9 @@ sub groupNgramsMultiSrc {
 		my $currNgramCounts = groupNgrams($ref->[$lineIdx], $order);
 
 		for my $currNgram (keys %$currNgramCounts) {
+			if (!exists $result{$currNgram}) {
+				$result{$currNgram} = 0;
+			}
 			$result{$currNgram} = max($result{$currNgram}, $currNgramCounts->{$currNgram});
 		}
 	}


### PR DESCRIPTION
… in hash.

Fixes the following errors in bootstrap-hypothesis-difference-significance.pl on Perl v5.14.2:

Use of uninitialized value $coocUpd in numeric gt (>) at /fs/lofn0/dmadl/software/mosesdecoder/scripts/analysis/bootstrap-hypothesis-difference-significance.pl line 317.
Use of uninitialized value $b in numeric lt (<) at /fs/lofn0/dmadl/software/mosesdecoder/scripts/analysis/bootstrap-hypothesis-difference-significance.pl line 543.
Use of uninitialized value $coocUpd in addition (+) at /fs/lofn0/dmadl/software/mosesdecoder/scripts/analysis/bootstrap-hypothesis-difference-significance.pl line 314.
Use of uninitialized value $coocUpd in numeric gt (>) at /fs/lofn0/dmadl/software/mosesdecoder/scripts/analysis/bootstrap-hypothesis-difference-significance.pl line 317.
Use of uninitialized value $a in numeric gt (>) at /fs/lofn0/dmadl/software/mosesdecoder/scripts/analysis/bootstrap-hypothesis-difference-significance.pl line 552.