### PR TITLE
Fixed for removed option building cooccurrence table.

### DIFF
--- a/scripts/training/build-mmsapt.perl
+++ b/scripts/training/build-mmsapt.perl
@@ -1,4 +1,7 @@
 #!/usr/bin/env perl
+#
+# This file is part of moses.  Its use is licensed under the GNU Lesser General
+# Public License version 2.1 or, at your option, any later version.
 
 use warnings;
 use strict;
@@ -20,5 +23,5 @@ die("ERROR: syntax is --alignment FILE --corpus FILESTEM --f EXT --e EXT --DIR O
 `$RealBin/../../bin/mtt-build < $CORPUS.$F -i -o $DIR/$F`;
 `$RealBin/../../bin/mtt-build < $CORPUS.$E -i -o $DIR/$E`;
 `$RealBin/../../bin/symal2mam < $ALIGNMENT $DIR/$F-$E.mam`;
-`$RealBin/../../bin/mmlex-build $DIR/ $F $E -o $DIR/$F-$E.lex -c $DIR/$F-$E.cooc`;
+`$RealBin/../../bin/mmlex-build $DIR/ $F $E -o $DIR/$F-$E.lex`;
 


### PR DESCRIPTION
For the newest revision of mosesdecoder, "scripts/training/build-mmsapt.perl" script didn't work because "mmlex-build" command no longer supports "-c [ --coor ] co-occurrence-file" option.
Therefore I removed this option from the script, too.
