### PR TITLE
Removing spurious outputs of "which" and "split --help" during training

### DIFF
--- a/scripts/generic/extract-parallel.perl
+++ b/scripts/generic/extract-parallel.perl
@@ -44,7 +44,7 @@ my $phraseOrientationPriorsFile;
 my $splitCmdOption = "";
 
 my $GZIP_EXEC;
-if(`which pigz`) {
+if(`which pigz 2> /dev/null`) {
   $GZIP_EXEC = 'pigz';
 }
 else {
@@ -374,7 +374,7 @@ sub NumStr($)
 sub GetSplitVersion($)
 {
 	my $splitCmd = shift;
-	my $retVal = system("$splitCmd --help");
+	my $retVal = system("$splitCmd --help > /dev/null");
 	if ($retVal != 0) {
 		return 1;
 	}

--- a/scripts/training/train-model.perl
+++ b/scripts/training/train-model.perl
@@ -415,7 +415,7 @@ else {
 }
 
 my $GZIP_EXEC;
-if(`which pigz`) {
+if(`which pigz 2> /dev/null`) {
   $GZIP_EXEC = 'pigz';
 }
 else {


### PR DESCRIPTION
In the most recent version of the ```train-model.perl``` and ```extract-parallel.perl``` scripts, the ```which``` command is used to detect whether to use ```pigz``` or ```gzip```.  On some machines, the ```which``` command prints to stderr when the executable is not found, leading to the following line in the generated logs:
```
which: no pigz in (/cluster/home/plison/bin:/opt/rocks/bin:/cluster/home/plison/bin:/opt/rocks/bin:
/cluster/home/plison/bin:/opt/rocks/bin:/cluster/software/VERSIONS/python3-3.2.3/bin:
/cluster/software/VERSIONS/boost/1.58.0/include:/cluster/software/VERSIONS/boost/1.58.0/lib:
/cluster/software/VERSIONS/boost/1.58.0/:/cluster/software/VERSIONS/openmpi.gnu-1.8.1/bin:
/cluster/software/VERSIONS/gcc-4.9.0/bin:/cluster/software/VERSIONS/cmake-3.1.0/bin:
/usit/abel/u1/plison/bin:/hpc/bin:/opt/gold/bin:/cluster/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/bin:
/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/ganglia/bin:/opt/ganglia/sbin:/opt/ibutils/bin:
/usr/java/latest/bin:/opt/rocks/bin:/opt/rocks/sbin)
```

This can be confusing, as it looks like an error message, while this is actually perfectly normal behaviour (the ```gzip``` command will be used instead of ```pigz```). 

Similarly, the ```split --help``` call in the ```GetSplitVersion``` subroutine of ```extract-parallel.perl``` outputs a long block containing the help description for the ```split``` command:

 ```
Usage: split [OPTION]... [INPUT [PREFIX]]
Output fixed-size pieces of INPUT to PREFIXaa, PREFIXab, ...; default
size is 1000 lines, and default PREFIX is `x'.  With no INPUT, or when INPUT
is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -a, --suffix-length=N   use suffixes of length N (default 2)
  -b, --bytes=SIZE        put SIZE bytes per output file
  -C, --line-bytes=SIZE   put at most SIZE bytes of lines per output file
  -d, --numeric-suffixes  use numeric suffixes instead of alphabetic
  -e, --elide-empty-files  do not generate empty output files with `-n'
  -l, --lines=NUMBER      put NUMBER lines per output file
  -n, --number=CHUNKS     generate CHUNKS output files.  See below
  -u, --unbuffered        immediately copy input to output with `-n r/...'
      --verbose           print a diagnostic just before each
                            output file is opened
      --help     display this help and exit
      --version  output version information and exit

SIZE may be (or may be an integer optionally followed by) one of following:
KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.

CHUNKS may be:
N       split into N files based on size of input
K/N     output Kth of N to stdout
l/N     split into N files without splitting lines
l/K/N   output Kth of N to stdout without splitting lines
r/N     like `l' but use round robin distribution
r/K/N   likewise but only output Kth of N to stdout

Report split bugs to bug-coreutils@gnu.org
GNU coreutils home page: <http://www.gnu.org/software/coreutils/>
General help using GNU software: <http://www.gnu.org/gethelp/>
Report split translation bugs to <http://translationproject.org/team/>
For complete documentation, run: info coreutils 'split invocation'
 ```

Again, this can be quite confusing, as it gives the false impression that there is an invocation error when calling the ```split``` command (while it is again perfectly normal).

To avoid this, this pull request simply redirects the stderr output of  ```which``` & the stdout output of ```split --help```  to ```/dev/null```. 