### PR TITLE
Make cube pruning deterministic

### DIFF
--- a/moses/BitmapContainer.h
+++ b/moses/BitmapContainer.h
@@ -61,6 +61,7 @@ private:
   size_t m_hypothesis_pos, m_translation_pos;
   Hypothesis *m_hypothesis;
   BackwardsEdge *m_edge;
+  TargetPhrase m_target_phrase;
 
   HypothesisQueueItem();
 
@@ -72,7 +73,8 @@ public:
     : m_hypothesis_pos(hypothesis_pos)
     , m_translation_pos(translation_pos)
     , m_hypothesis(hypothesis)
-    , m_edge(edge) {
+    , m_edge(edge)
+    , m_target_phrase(hypothesis->GetCurrTargetPhrase()) {
   }
 
   ~HypothesisQueueItem() {
@@ -93,6 +95,10 @@ public:
   BackwardsEdge *GetBackwardsEdge() {
     return m_edge;
   }
+
+  TargetPhrase& GetTargetPhrase() {
+    return m_target_phrase;
+  }
 };
 
 //! Allows comparison of two HypothesisQueueItem objects by the corresponding scores.
@@ -103,20 +109,13 @@ public:
     float scoreA = itemA->GetHypothesis()->GetTotalScore();
     float scoreB = itemB->GetHypothesis()->GetTotalScore();
 
-    return (scoreA < scoreB);
+    if (scoreA != scoreB)
+    {
+      return (scoreA < scoreB);
+    }
 
-    /*
-    {
-    	return true;
-    }
-    else if (scoreA < scoreB)
-    {
-    	return false;
-    }
-    else
-    {
-    	return itemA < itemB;
-    }*/
+    // Equal scores: break ties deterministically by comparing target phrases
+    return (itemA->GetTargetPhrase().Compare(itemB->GetTargetPhrase()) < 0);
   }
 };
 


### PR DESCRIPTION
This is again a pull request so other people can take a look.  There is an edge case with cube pruning where sort order is undefined for hypotheses with different translations but equal overall model scores.  This means that running the same test set multiple times could produce different outputs (more of a problem with smaller data where phrase pairs are more likely to have the same scores).

The simple fix for this was to break ties by comparing the current target phrases in each hypothesis, but this led to some concurrency problems.  Hypotheses keep pointers to target phrases, and these pointers kept getting deleted by other threads in the middle of comparisons, leading to segfaults.  I got around this by making a copy of the target phrase in each hypothesis, which incurs a minimal (1-2%) slowdown in decoding.  This is a good trade for my use case, but if other people feel strongly about it, deterministic tie breaking could be factored out as a config option.  I briefly looked at fixing the concurrency problem, but that turns into a pretty deep rabbit hole with lots of raw pointer management across many classes.  Refactoring that code would be a pretty significant undertaking.

I can merge this in if there are no objections, but I wanted to make sure no one would be negatively affected.