### PR TITLE
add --with-address-sanitizer option to Jamroot build file

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -143,6 +143,13 @@ if [ option.get "debug-build" : : "yes" ] {
    echo "Building with -Og to enable easier profiling and debugging. Only available on gcc 4.8+." ;
 }
 
+if [ option.get "with-address-sanitizer" : : "yes" ] {
+  requirements += <cxxflags>-fsanitize=address ;
+  requirements += <cxxflags>-fno-omit-frame-pointer ;
+  requirements += <linkflags>-fsanitize=address ;
+  echo "Building with AddressSanitizer to enable debugging of memory errors. Only available on gcc 4.8+." ;
+}
+
 if [ option.get "enable-mpi" : : "yes" ] {
   import mpi ;
   using mpi ;


### PR DESCRIPTION
AddressSanitizer (built into gcc since 4.8) helps tracking down memory errors. Similar to valgrind --tool=memcheck, but with MUCH less overhead.