### PR TITLE
fixes parameter mismatch in LM::Load

### DIFF
--- a/moses/LM/MaxEntSRI.cpp
+++ b/moses/LM/MaxEntSRI.cpp
@@ -66,7 +66,7 @@ LanguageModelMaxEntSRI::~LanguageModelMaxEntSRI()
   delete m_srilmVocab;
 }
 
-void LanguageModelMaxEntSRI::Load(AllOptions const& opts)
+void LanguageModelMaxEntSRI::Load(AllOptions::ptr const& opts)
 {
   m_srilmVocab  = new ::Vocab();
   m_srilmModel	= new MEModel(*m_srilmVocab, m_nGramOrder);

--- a/moses/LM/NeuralLMWrapper.cpp
+++ b/moses/LM/NeuralLMWrapper.cpp
@@ -22,7 +22,7 @@ NeuralLMWrapper::~NeuralLMWrapper()
 }
 
 
-void NeuralLMWrapper::Load(AllOptions const& opts)
+void NeuralLMWrapper::Load(AllOptions::ptr const& opts)
 {
 
   // Set parameters required by ancestor classes

--- a/moses/LM/RDLM.cpp
+++ b/moses/LM/RDLM.cpp
@@ -39,7 +39,7 @@ RDLM::~RDLM()
   delete lm_label_base_instance_;
 }
 
-void RDLM::Load(AllOptions const& opts)
+void RDLM::Load(AllOptions::ptr const& opts)
 {
 
   lm_head_base_instance_ = new nplm::neuralTM();

--- a/moses/LM/Rand.cpp
+++ b/moses/LM/Rand.cpp
@@ -52,7 +52,7 @@ LanguageModelRandLM::~LanguageModelRandLM()
   delete m_lm;
 }
 
-void LanguageModelRandLM::Load(AllOptions const& opts)
+void LanguageModelRandLM::Load(AllOptions::ptr const& opts)
 {
   cerr << "Loading LanguageModelRandLM..." << endl;
   FactorCollection &factorCollection = FactorCollection::Instance();

--- a/moses/LM/oxlm/OxLM.cpp
+++ b/moses/LM/oxlm/OxLM.cpp
@@ -70,7 +70,7 @@ void OxLM<Model>::SetParameter(const string& key, const string& value)
 }
 
 template<class Model>
-void OxLM<Model>::Load(AllOptions const& opts)
+void OxLM<Model>::Load(AllOptions::ptr const& opts)
 {
   model.load(m_filePath);
 


### PR DESCRIPTION
The parameter type on LM::Load changed to AllOptions::ptr, but it did not get changed in the implementations of:
  * moses/LM/MaxEntSRI.cpp
  * moses/LM/NeuralLMWrapper.cpp
  * moses/LM/RDLM.cpp
  * moses/LM/Rand.cpp
  * moses/LM/oxlm/OxLM.cpp
