### PR TITLE
Fix mert-moses multi-moses for IRSTLM

### DIFF
--- a/scripts/generic/multi_moses.py
+++ b/scripts/generic/multi_moses.py
@@ -232,7 +232,7 @@ def main(argv):
     if show_weights:
         sys.stdout.write(subprocess.check_output(cmd))
         sys.stdout.flush()
-        sys.exit(0)
+        return
 
     # Check inputs
     if not (len(cmd) > 0 and moses_ini):

--- a/scripts/training/mert-moses.pl
+++ b/scripts/training/mert-moses.pl
@@ -1404,6 +1404,10 @@ sub get_featlist_from_moses {
     $cmd .= "$___DECODER $___DECODER_FLAGS -config $configfn";
     $cmd .= " -inputtype $___INPUTTYPE" if defined($___INPUTTYPE);
     $cmd .= " -show-weights";
+    if (defined $___USE_MULTI_MOSES) {
+      # Pass moses command through multi-moses script to handle threads properly
+      $cmd = "$___MULTI_MOSES $cmd";
+    }
     print STDERR "Executing: $cmd\n";
     &submit_or_exec($cmd, $featlistfn, "/dev/null", 1);
   }


### PR DESCRIPTION
This addresses #141.  For ease of use, multi_moses.py overloads the --threads option to figure out how many processes to run and how many threads to give each process.  I had only updated mert-moses.pl to prefix the decoding moses command with with multi_moses.py, not the show-weights command.  This led to the threads flag being passed to moses and triggering an exception with IRSTLM.

This commit also prefixes the show-weights command, a case handled by multi_moses.py.  I don't use IRSTLM so I haven't tested it myself.  Can someone who uses IRST please verify that this fixes the problem and comment below?  Thanks!