### PR TITLE
Fixes for build scripts

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,8 +1,8 @@
 #!/bin/bash 
-# this script assumes that all 3rd-party dependencies are installed under ./opt
+# if not supplied otherwise, this script assumes that all 3rd-party dependencies are installed under ./opt
 # you can install all 3rd-party dependencies by running make -f contrib/Makefiles/install-dependencies.gmake
 
 set -e -o pipefail
-opt=$(pwd)/opt
-./bjam --with-irstlm=$opt/irstlm-5.80.08 --with-boost=$opt --with-cmph=$opt --with-xmlrpc-c=$opt --with-mm --with-probing-pt -j$(getconf _NPROCESSORS_ONLN) $@
+OPT=${OPT:-$(pwd)/OPT}
+./bjam --with-irstlm=$OPT/irstlm-5.80.08 --with-boost=$OPT --with-cmph=$OPT --with-xmlrpc-c=$OPT --with-mm --with-probing-pt -j$(getconf _NPROCESSORS_ONLN) $@
 

--- a/contrib/Makefiles/install-dependencies.gmake
+++ b/contrib/Makefiles/install-dependencies.gmake
@@ -87,7 +87,7 @@ irstlm: | $(call safepath,$(IRSTLM_PREFIX)/bin/build-lm.sh)
 $(call safepath,$(IRSTLM_PREFIX)/bin/build-lm.sh):
 	$(sfget)
 	cd $$(find '${TMP}' -name trunk) && ./regenerate-makefiles.sh \
-	&& ./configure --prefix='${PREFIX}' && make -j${shell getconf _NPROCESSORS_ONLN} && make install -j$(shell getconf _NPROCESSORS_ONLN)
+	&& ./configure --prefix='${PREFIX}' && make -j${nproc} && make install -j${nproc}
 	rm -rf ${TMP}
 
 # boost 
@@ -97,5 +97,5 @@ boost: PREFIX=${BOOST_PREFIX}
 boost: | $(call safepath,${BOOST_PREFIX}/include/boost)
 $(call safepath,${BOOST_PREFIX}/include/boost):
 	$(sfget)
-	cd '${TMP}/boost_1_59_0' && ./bootstrap.sh && ./b2 --prefix=${PREFIX} -j$(shell getconf _NPROCESSORS_ONLN) install
+	cd '${TMP}/boost_1_59_0' && ./bootstrap.sh && ./b2 --prefix=${PREFIX} -j${nproc} install
 	rm -rf ${TMP}

--- a/contrib/Makefiles/install-dependencies.gmake
+++ b/contrib/Makefiles/install-dependencies.gmake
@@ -56,7 +56,7 @@ sourceforge = http://downloads.sourceforge.net/project
 nproc := $(shell getconf _NPROCESSORS_ONLN)
 sfget  = mkdir -p '${TMP}' && cd '${TMP}' && wget -qO- ${URL} | tar xz 
 configure-make-install  = cd '$1' && ./configure --prefix='${PREFIX}' 
-configure-make-install += && make -j$(getconf _NPROCESSORS_ONLN) && make install
+configure-make-install += && make -j${nproc} && make install
 
 # XMLRPC-C for moses server
 xmlrpc: URL=$(sourceforge)/xmlrpc-c/Xmlrpc-c%20Super%20Stable/1.33.17/xmlrpc-c-1.33.17.tgz

--- a/contrib/Makefiles/install-dependencies.gmake
+++ b/contrib/Makefiles/install-dependencies.gmake
@@ -61,7 +61,7 @@ configure-make-install += && make -j${nproc} && make install
 # XMLRPC-C for moses server
 xmlrpc: URL=$(sourceforge)/xmlrpc-c/Xmlrpc-c%20Super%20Stable/1.33.17/xmlrpc-c-1.33.17.tgz
 xmlrpc: TMP=$(CWD)/build/xmlrpc
-xmlrpc: PREFIX=${XMLRPC_PREFIX}
+xmlrpc: override PREFIX=${XMLRPC_PREFIX}
 xmlrpc: | $(call safepath,${XMLRPC_PREFIX}/bin/xmlrpc-c-config)
 $(call safepath,${XMLRPC_PREFIX}/bin/xmlrpc-c-config):
 	$(sfget)
@@ -71,7 +71,7 @@ $(call safepath,${XMLRPC_PREFIX}/bin/xmlrpc-c-config):
 # CMPH for CompactPT
 cmph: URL=$(sourceforge)/cmph/cmph/cmph-2.0.tar.gz
 cmph: TMP=$(CWD)/build/cmph
-cmph: PREFIX=${CMPH_PREFIX}
+cmph: override PREFIX=${CMPH_PREFIX}
 cmph: | $(call safepath,${CMPH_PREFIX}/bin/cmph)
 $(call safepath,${CMPH_PREFIX}/bin/cmph):
 	$(sfget)
@@ -82,7 +82,7 @@ $(call safepath,${CMPH_PREFIX}/bin/cmph):
 irstlm: URL=$(sourceforge)/irstlm/irstlm/irstlm-5.80/irstlm-5.80.08.tgz
 irstlm: TMP=$(CWD)/build/irstlm
 irstlm: VERSION=$(basename $(notdir $(irstlm_url)))
-irstlm: PREFIX=${IRSTLM_PREFIX}
+irstlm: override PREFIX=${IRSTLM_PREFIX}
 irstlm: | $(call safepath,$(IRSTLM_PREFIX)/bin/build-lm.sh)
 $(call safepath,$(IRSTLM_PREFIX)/bin/build-lm.sh):
 	$(sfget)
@@ -93,7 +93,7 @@ $(call safepath,$(IRSTLM_PREFIX)/bin/build-lm.sh):
 # boost 
 boost: URL=http://sourceforge.net/projects/boost/files/boost/1.59.0/boost_1_59_0.tar.gz/download
 boost: TMP=$(CWD)/build/boost
-boost: PREFIX=${BOOST_PREFIX}
+boost: override PREFIX=${BOOST_PREFIX}
 boost: | $(call safepath,${BOOST_PREFIX}/include/boost)
 $(call safepath,${BOOST_PREFIX}/include/boost):
 	$(sfget)


### PR DESCRIPTION
1. `install-dependencies.gmake` tries to use multiple cores for all builds, but for tasks using the `configure-make-install` function the `-j` value is set incorrectly (it expands to just `-j` instead of `-jN` where `N` is the number of processors available). Thus these builds are not parallelized. I also did some minor cleanup to ensure that the actual number of processors is only computed once, and then is used consistently throughout the script.

2. The make script lets you specify a location for the `opt` dir, but `compile.sh` has the location hard-coded. I have made it possible to set this when calling `compile.sh`.

3. Supplying a `PREFIX=...` to the make script does not have the intended effect for irstlm because make treats variables provided by the caller on the CLI as immutable. This is fixed by using the [`override` directive](https://www.gnu.org/software/make/manual/html_node/Overriding.html).