### PR TITLE
fixes std::bad_alloc in processPhraseTableMin for large models

### DIFF
--- a/moses/TranslationModel/CompactPT/CanonicalHuffman.h
+++ b/moses/TranslationModel/CompactPT/CanonicalHuffman.h
@@ -76,8 +76,9 @@ private:
     MinHeapSorter hs(A);
     std::make_heap(A.begin(), A.begin() + n, hs);
 
-    size_t h = n;
-    size_t m1, m2;
+    // marked volatile to prevent the intel compiler from generating bad code
+    volatile size_t h = n;
+    volatile size_t m1, m2;
     while(h > 1) {
       m1 = A[0];
       std::pop_heap(A.begin(), A.begin() + h, hs);


### PR DESCRIPTION
 + only seems to affect the Intel compiler

When running processPhraseTableMin with a large phrase table, I would get a std::bad_alloc error. It appears that the Intel compiler is being too aggressive in its optimizations. Adding 'volatile' to the loop variables seems to let it complete without issue. GCC doesn't have this problem.