### PR TITLE
avoid name collisions when filtering multiple reordering tables

### DIFF
--- a/moses/Parameter.cpp
+++ b/moses/Parameter.cpp
@@ -263,7 +263,6 @@ Parameter::Parameter()
   AddParam(misc_opts,"references", "Reference file(s) - used for bleu score feature");
   AddParam(misc_opts,"recover-input-path", "r", "(conf net/word lattice only) - recover input path corresponding to the best translation");
   AddParam(misc_opts,"link-param-count", "Number of parameters on word links when using confusion networks or lattices (default = 1)");
-  AddParam(misc_opts,"description", "Source language, target language, description");
   AddParam(misc_opts,"feature-name-overwrite", "Override feature name (NOT arguments). Eg. SRILM-->KENLM, PhraseDictionaryMemory-->PhraseDictionaryScope3");
 
   AddParam(misc_opts,"feature", "All the feature functions should be here");

--- a/scripts/training/filter-model-given-input.pl
+++ b/scripts/training/filter-model-given-input.pl
@@ -224,6 +224,7 @@ while(my $line = <INI>) {
   elsif ($line =~ /LexicalReordering /) {
     print STDERR "ro:$line\n";
 		my ($source_factor, $t, $w, $file); # = ($1,$2,$3,$4);
+		my $dest_factor;
 
     for (my $i = 1; $i < scalar(@toks); ++$i) {
       my @args = split(/=/, $toks[$i]);
@@ -238,6 +239,7 @@ while(my $line = <INI>) {
 			}
 			elsif ($args[0] eq "output-factor") {
 			  #$t = chomp($args[1]);
+			  $dest_factor = $args[1];
 			}
 			elsif ($args[0] eq "type") {
 			  $t = $args[1];
@@ -254,6 +256,13 @@ while(my $line = <INI>) {
 		$file =~ s/^.*\/+([^\/]+)/$1/g;
 		my $new_name = "$dir/$file";
 		$new_name =~ s/\.gz//;
+
+		# avoid name collisions for multiple reordering tables; using phrase-table numbering scheme (except for TABLE_NUMBER)
+		$new_name .= ".$source_factor-$dest_factor";
+		my $cnt = 1;
+		$cnt ++ while (defined $new_name_used{"$new_name.$cnt"});
+		$new_name .= ".$cnt";
+		$new_name_used{$new_name} = 1;
 
 		#print INI_OUT "$source_factor $t $w $new_name\n";
 	  @toks = set_value(\@toks, "path", "$new_name");


### PR DESCRIPTION
Previously, filter-model-given-input.pl would only filter a single lexicalized reordering table with a given name.  For example, in moses.ini:

    # before filtering
    LexicalReordering name=LexicalReordering0 [...] path=model0/reordering-table.wbe-mslr-backward-fe.gz
    LexicalReordering name=LexicalReordering1 [...] path=model1/reordering-table.wbe-mslr-backward-fe.gz

    # after filtering - name collision
    LexicalReordering name=LexicalReordering0 [...] path=filtered/reordering-table.wbe-mslr-backward-fe 
    LexicalReordering name=LexicalReordering1 [...] path=filtered/reordering-table.wbe-mslr-backward-fe 

After this pull request, filtering results in a moses.ini with:

    LexicalReordering [...] path=filtered/reordering-table.wbe-mslr-backward-fe.0-0.1 
    LexicalReordering [...] path=filtered/reordering-table.wbe-mslr-backward-fe.0-0.2 

where the numbering scheme was copied from phrase table (except for `$TABLE_NUMBER`, which I wasn't quite sure how to handle).  I'm not really sure whether this is overkill, since I don't have any experience using factored models.

This pull request indirectly affects: `mert-moses.pl`, which filters phrase and reordering tables by default.  There is also a minor fix to documentation in the other commit.

Thank you!