### PR TITLE
Separate comma after a number end sentence

### DIFF
--- a/scripts/tokenizer/tokenizer.perl
+++ b/scripts/tokenizer/tokenizer.perl
@@ -284,6 +284,9 @@ sub tokenize
     # will also space digit,letter or letter,digit forms (redundant with next section)
     $text =~ s/([^\p{IsN}])[,]/$1 , /g;
     $text =~ s/[,]([^\p{IsN}])/ , $1/g;
+    
+    # separate "," after a number if it's the end of a sentence
+    $text =~ s/([\p{IsN}])[,]$/$1 ,/g;
 
     # separate , pre and post number
     #$text =~ s/([\p{IsN}])[,]([^\p{IsN}])/$1 , $2/g;


### PR DESCRIPTION
In the tokenizer: separate "," after a number if it's the end of a line (common in poetry).

Example:

> He is tall,
> He was born in **1800,**
> He died in **1900,** he was 100.
> He wants to go there in 2000.

Is currently tokenized as:

> He is tall ,
> He was born in **1800,**
> He died in **1900 ,** he was 100 .
> He wants to go there in 2000 .

Would be tokenized with this pull request as:

> He is tall ,
> He was born in **1800 ,**
> He died in **1900 ,** he was 100 .
> He wants to go there in 2000 .