### PR TITLE
Support multiple output factors for XML-specified translations

### DIFF
--- a/moses/XmlOption.cpp
+++ b/moses/XmlOption.cpp
@@ -479,8 +479,18 @@ ProcessAndStripXMLTags(AllOptions const& opts, string &line,
 
               Range range(startPos + offset,endPos-1 + offset); // span covered by phrase
               TargetPhrase targetPhrase(firstPt);
-              // targetPhrase.CreateFromString(Output, outputFactorOrder,altTexts[i],factorDelimiter, NULL);
-              targetPhrase.CreateFromString(Output, outputFactorOrder,altTexts[i], NULL);
+              // Target factors may be used by intermediate models (example: a
+              // generation model produces a factor used by a class-based LM
+              // but NOT output.  Fake the output factor order to match the
+              // number of factors specified in the alt text.  A one-factor
+              // system would have "word", a two-factor system would have
+              // "word|class", and so on.
+              vector<FactorType> fakeOutputFactorOrder;
+              size_t factorsInAltText = Tokenize(altTexts[i], StaticData::Instance().GetFactorDelimiter()).size();
+              for (size_t f = 0; f < factorsInAltText; ++f) {
+                fakeOutputFactorOrder.push_back(f);
+              }
+              targetPhrase.CreateFromString(Output, fakeOutputFactorOrder, altTexts[i], NULL);
 
               // lhs
               const UnknownLHSList &lhsList = opts.syntax.unknown_lhs; // staticData.GetUnknownLHS();

--- a/moses/XmlOption.cpp
+++ b/moses/XmlOption.cpp
@@ -486,7 +486,8 @@ ProcessAndStripXMLTags(AllOptions const& opts, string &line,
               // system would have "word", a two-factor system would have
               // "word|class", and so on.
               vector<FactorType> fakeOutputFactorOrder;
-              size_t factorsInAltText = Tokenize(altTexts[i], StaticData::Instance().GetFactorDelimiter()).size();
+              // Factors in first word of alt text
+              size_t factorsInAltText = TokenizeMultiCharSeparator(Tokenize(altTexts[i])[0], StaticData::Instance().GetFactorDelimiter()).size();
               for (size_t f = 0; f < factorsInAltText; ++f) {
                 fakeOutputFactorOrder.push_back(f);
               }


### PR DESCRIPTION
Posting a pull request to get another pair of eyes on this before checking in.  Basically XML input segfaulted for systems with multiple target factors, specifically when using a generation model for intermediate factors.  One such case is using a TM that translates factor 0, a GM that generates factor 1, and a class-based LM that scores factor 1.  The XML phrase is evaluated outside of the normal decode steps so there is no factor 1 and Moses segfaults.  The code does support specifying multiple factors on XML translations, but it is limited by the number of output factors.  If the system uses factor 1 intermediately but doesn't output it, Moses thinks there's only factor 0.

This patch allows users to specify all factors for an XML translation regardless of how many output factors there are.  Words in the generated target phrases get as many factors as are present.  Default behavior is unchanged and performance is unaffected.