### PR TITLE
Fix for number at the end of a string

### DIFF
--- a/scripts/generic/ph_numbers.perl
+++ b/scripts/generic/ph_numbers.perl
@@ -88,7 +88,7 @@ sub recognize {
           $isRecognized = 0;
         }
 
-        if ($end == length($input) -1 || substr($input, $end, 1) eq " ") {
+        if ($end == length($input) || substr($input, $end, 1) eq " ") {
         # last word, or next char is a space
         }
         else {


### PR DESCRIPTION
If passed a number at the end of the string, the placeholder replacement was not working.  For example:
"This is a 5"
would not replace the "5".