### PR TITLE
Changed \p{Hyphen} to \p{Line_Break} in mteval-v13a.pl

### DIFF
--- a/scripts/generic/mteval-v13a.pl
+++ b/scripts/generic/mteval-v13a.pl
@@ -19,6 +19,8 @@ binmode STDERR, ":utf8";
 # version 13a
 #    * modified the scoring functions to prevent division-by-zero errors when a system segment is empty
 #        * affected methods: 'bleu_score' and 'bleu_score_smoothing'
+#    * use \p{Line_Breaks} instead of \p{Hyphen} when stripping end-of-line hyphenation and join lines
+#        * because \p{Hyphen} is deprecated since 2016-06-01, see http://www.unicode.org/reports/tr14/#Hyphen
 #
 # version 13
 #    * Uses a XML parser to read data (only when extension is .xml)
@@ -948,7 +950,7 @@ sub tokenization_international
 	my ($norm_text) = @_;
 
 	$norm_text =~ s/<skipped>//g; # strip "skipped" tags
-	$norm_text =~ s/\p{Hyphen}\p{Zl}//g; # strip end-of-line hyphenation and join lines
+	$norm_text =~ s/\p{Line_Break}\p{Zl}//g; # strip end-of-line hyphenation and join lines
 	$norm_text =~ s/\p{Zl}/ /g; # join lines
 
 	# replace entities


### PR DESCRIPTION
Using Perl v5.18.2, it's reporting this warning:

> Use of 'Hyphen' in \p{} or \P{} is deprecated because: Supplanted by Line_Break property values; see www.unicode.org/reports/tr14


```
~$ cat ref.sgm 
<refset setid="newstest2015" srclang="any" trglang="en">
<doc sysid="ref" docid="1012-bbc" genre="news" origlang="en">
<p>
<seg id="1">let it go</seg>
</p>
</doc>
</refset>

~$ cat hyp.sgm 
<tstset setid="newstest2015" srclang="any" trglang="en">
<doc sysid="h1" docid="1012-bbc" genre="news" origlang="en">
<p>
<seg id="1">let got it</seg>
</p>
</doc>
</tstset>

~$ cat src.sgm 
<srcset setid="newstest2015" srclang="any">
<doc sysid="src" docid="1012-bbc" genre="news" origlang="en">
<p>
<seg id="01">let it go</seg>
</p>
</doc>
</srcset>

~$ perl ~/mosesdecoder/scripts/generic/mteval-v13a.pl -r ref.sgm -s src.sgm -t hyp.sgm 
Use of 'Hyphen' in \p{} or \P{} is deprecated because: Supplanted by Line_Break property values; see www.unicode.org/reports/tr14; at /Users/liling.tan/mosesdecoder/scripts/generic/mteval-v13a.pl line 951.
MT evaluation scorer began on 2016 Dec 23 at 13:57:38
command line:  /Users/liling.tan/mosesdecoder/scripts/generic/mteval-v13a.pl -r ref.sgm -s src.sgm -t hyp.sgm
  Evaluation of any-to-en translation using:
    src set "newstest2015" (1 docs, 1 segs)
    ref set "newstest2015" (1 refs)
    tst set "newstest2015" (1 systems)

length ratio: 1 (3/3), penalty (log): 0
NIST score = 1.0566  BLEU score = 0.4518 for system "h1"

# ------------------------------------------------------------------------

Individual N-gram scoring
        1-gram   2-gram   3-gram   4-gram   5-gram   6-gram   7-gram   8-gram   9-gram
        ------   ------   ------   ------   ------   ------   ------   ------   ------
 NIST:  1.0566   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000  "h1"

 BLEU:  0.6667   0.2500   0.2500   1.0000   1.0000   1.0000   1.0000   1.0000   1.0000  "h1"

# ------------------------------------------------------------------------
Cumulative N-gram scoring
        1-gram   2-gram   3-gram   4-gram   5-gram   6-gram   7-gram   8-gram   9-gram
        ------   ------   ------   ------   ------   ------   ------   ------   ------
 NIST:  1.0566   1.0566   1.0566   1.0566   1.0566   1.0566   1.0566   1.0566   1.0566  "h1"

 BLEU:  0.6667   0.4082   0.3467   0.4518   0.5296   0.5888   0.6351   0.6722   0.7025  "h1"
MT evaluation scorer ended on 2016 Dec 23 at 13:57:38
```