### PR TITLE
Fixing errors while building with oxlm

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -183,7 +183,6 @@ requirements += [ option.get "with-mm" : : <define>MAX_NUM_FACTORS=4 ] ;
 requirements += [ option.get "unlabelled-source" : : <define>UNLABELLED_SOURCE ] ;
 
 if [ option.get "with-oxlm" ] {
-  external-lib boost_serialization ;
   external-lib gomp ;
   requirements += <library>boost_serialization ;
   requirements += <library>gomp ;

--- a/moses/TranslationModel/UG/mm/ug_typedefs.h
+++ b/moses/TranslationModel/UG/mm/ug_typedefs.h
@@ -36,7 +36,7 @@ namespace sapt
 #ifndef SPTR
 #define SPTR   boost::shared_ptr
 #endif
-#define iptr   boost::intrusive_ptr
+#define boost_iptr   boost::intrusive_ptr
 #define scoptr boost::scoped_ptr
 #define rcast  reinterpret_cast
 #endif

--- a/moses/TranslationModel/UG/test-ranked-phrase-lookup.cc
+++ b/moses/TranslationModel/UG/test-ranked-phrase-lookup.cc
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
 {
   typedef vector<PhrasePair<Token> > pplist_t;
   interpret_args(argc, argv);
-  iptr<mmbitext> Bptr(new mmbitext);
+  boost_iptr<mmbitext> Bptr(new mmbitext);
   mmbitext& B = *Bptr;// static_cast<mmbitext*>(Bptr.get());
   B.open(bname, L1, L2);
   B.V1->setDynamic(true);


### PR DESCRIPTION
- I've renamed **iptr** to **boost_iptr** because of a conflict with _eigen_ library required by oxlm (it has some variables named **iptr** which prevented moses from compilation when --with-oxlm is issued)
-I've modified Jamroot, let boost_serialization be just a required library for OxLM, removed the line mentioning it as an external dependency. Previously, It was not passed to some build command that needed it so they failed finding libboost_serialization, but now everything is okay.

Now Moses compiles successfully with OxLM in both shared and static linking.
