### PR TITLE
adding the config of travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+dist: trusty
+language: c
+compiler: gcc
+env:
+  matrix: 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - subversion
+      - automake
+      - libtool
+      - zlib1g-dev
+      - libbz2-dev
+      - liblzma-dev
+      - libboost-all-dev
+      - libgoogle-perftools-dev
+      - libxmlrpc-c++.*-dev
+      - cmake
+      - csh
+script:
+- ./bjam -j4


### PR DESCRIPTION
squashed version of #178 

It need register on <https://travis-ci.org/> before merging this branch.
If you feel its notifications are too noising, you can add `branch` setting in `.travis.yml` like [this](https://github.com/sih4sing5hong5/tai5-uan5_gian5-gi2_kang1-ku7/blob/master/.travis.yml#L38-L41).