### PR TITLE
Typo correction, single quote citations and numbers tokenization

### DIFF
--- a/scripts/tokenizer/tokenizer.perl
+++ b/scripts/tokenizer/tokenizer.perl
@@ -257,13 +257,18 @@ sub tokenize
     $text =~ s/^ //g;
     $text =~ s/ $//g;
 
-    # seperate out all "other" special characters
+    # separate out all "other" special characters
     $text =~ s/([^\p{IsAlnum}\s\.\'\`\,\-])/ $1 /g;
 
     # aggressive hyphen splitting
     if ($AGGRESSIVE)
     {
-        $text =~ s/([\p{IsAlnum}])\-(?=[\p{IsAlnum}])/$1 \@-\@ /g;
+        # $text =~ s/([\p{IsAlnum}])\-(?=[\p{IsAlnum}])/$1 \@-\@ /g;
+        # Does not split hyphen between numbers
+        $text =~ s/([\p{IsAlpha}])\-(?=[\p{IsAlpha}])/$1 \@-\@ /g;
+        $text =~ s/^\-(?=[\p{IsAlpha}])/- /g;
+        $text =~ s/(\s)\-(?=[\p{IsAlnum}])/$1- /g;
+        $text =~ s/(?<=[\p{IsAlnum}])\-(\s)/ -$1/g;
     }
 
     #multi-dots stay together
@@ -315,6 +320,10 @@ sub tokenize
         $text =~ s/([^\p{IsAlpha}])[']([\p{IsAlpha}])/$1 ' $2/g;
         $text =~ s/([\p{IsAlpha}])[']([^\p{IsAlpha}])/$1 ' $2/g;
         $text =~ s/([\p{IsAlpha}])[']([\p{IsAlpha}])/$1' $2/g;
+        # "'" at the beginning of a line
+        $text =~ s/^[']/' /g;
+        # "'" at the end of a line
+        $text =~ s/[']$/ '/g;
     }
     else
     {


### PR DESCRIPTION
Hi,

I thought I'd already done this PR, unfortunately no...

Typo: "seperate" => "separate in comments"

----------

`# "'" at the beginning of a line`
`$text =~ s/^[']/' /g;`
`# "'" at the end of a line`
`$text =~ s/[']$/ '/g;`

Because single quotes are used are single quotation marks. So `'This is impossible'` should be tokenized as `' This is impossible '`.

----------

The other modification is to avoid series of numbers and letters for instance to be separated:
* L. 35-2-a
* L.35-2-a
* L. 35-2-a-
* L.35-2-a-
* L. 35-2
* L.35-2
* L. 35-2
* L.35-2