### PR TITLE
filter-model-given input.pl - update for OnDiskPT and ProbingPT

### DIFF
--- a/scripts/training/filter-model-given-input.pl
+++ b/scripts/training/filter-model-given-input.pl
@@ -386,7 +386,7 @@ for ( my $i = 0 ; $i <= $#TABLE ; $i++ ) {
     $mid_file .= ".gz"
       if $mid_file !~ /\.gz/
       && $binarizer
-      && $binarizer =~ /processPhraseTable/;
+      && $binarizer =~ /processPhraseTable|CreateOnDiskPt|CreateProbingPT/;
 
     my $openstring = mk_open_string($file);
 


### PR DESCRIPTION
The .gz extension should be also added for 'On Disk' and 'Probing' Phrase tables, otherwise the TRAINING:binarize-config phase fails in EMS. Reproducible when the binarize-all parameter is enabled.