### PR TITLE
Korean words has spaces =)

### DIFF
--- a/scripts/tokenizer/detokenizer.perl
+++ b/scripts/tokenizer/detokenizer.perl
@@ -106,7 +106,7 @@ sub detokenize {
 	my $prependSpace = " ";
 	for ($i=0;$i<(scalar(@words));$i++) {		
 		if (&startsWithCJKChar($words[$i])) {
-		    if ($i > 0 && &endsWithCJKChar($words[$i-1])) {
+		    if (($i > 0 && &endsWithCJKChar($words[$i-1])) && ($language ne "ko")) {
 			# perform left shift if this is a second consecutive CJK (Chinese/Japanese/Korean) word
 			$text=$text.$words[$i];
 		    } else {


### PR DESCRIPTION
Korean words should be treated similarly to English. Although the characters falls under the CJK charset, it does retain the spaces in natural text. 

It was quite a gotcha to see the spaces disappear when detokenizing =)