### PR TITLE
add fi/sv-specific colon handling in tokenizer.perl

### DIFF
--- a/scripts/tokenizer/tokenizer.perl
+++ b/scripts/tokenizer/tokenizer.perl
@@ -257,8 +257,17 @@ sub tokenize
     $text =~ s/^ //g;
     $text =~ s/ $//g;
 
-    # seperate out all "other" special characters
-    $text =~ s/([^\p{IsAlnum}\s\.\'\`\,\-])/ $1 /g;
+    # separate out all "other" special characters
+    if (($language eq "fi") or ($language eq "sv")) {
+        # in Finnish and Swedish, the colon can be used inside words as an apostrophe-like character:
+        # USA:n, 20:een, EU:ssa, USA:s, S:t
+        $text =~ s/([^\p{IsAlnum}\s\.\:\'\`\,\-])/ $1 /g;
+        # if a colon is not immediately followed by lower-case characters, separate it out anyway
+        $text =~ s/(:)(?=$|[^\p{Ll}])/ $1 /g;
+    }
+    else {
+        $text =~ s/([^\p{IsAlnum}\s\.\'\`\,\-])/ $1 /g;
+    }
 
     # aggressive hyphen splitting
     if ($AGGRESSIVE)


### PR DESCRIPTION
Hi,
This fix prevents word-internal colons from being split into separate tokens in Finnish (and Swedish, while we're at it). See
https://en.wikipedia.org/wiki/Colon_(punctuation)#Word-medial_separator
and
https://en.wikipedia.org/wiki/Colon_(punctuation)#Abbreviation
