### PR TITLE
 fix symlink path in Jamroot when using --prefix

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -338,8 +338,8 @@ if [ path.exists $(TOP)/dist ] && $(prefix) != dist {
 }
 
 #local temp = [ _shell "bash source ./s.sh" ] ;
-local temp = [ _shell "mkdir -p $(TOP)/bin" ] ;
-local temp = [ _shell "rm -f $(TOP)/bin/moses_chart" ] ;
-local temp = [ _shell "cd $(TOP)/bin && ln -sf moses moses_chart" ] ;
-local temp = [ _shell "cd $(TOP)/bin && ln -sf CreateProbingPT CreateProbingPT2" ] ;
+local temp = [ _shell "mkdir -p $(PREFIX)/bin" ] ;
+local temp = [ _shell "rm -f $(PREFIX)/bin/moses_chart" ] ;
+local temp = [ _shell "cd $(PREFIX)/bin && ln -sf moses moses_chart" ] ;
+local temp = [ _shell "cd $(PREFIX)/bin && ln -sf CreateProbingPT CreateProbingPT2" ] ;
 


### PR DESCRIPTION
As written on the mailing list:

On the last line of mosesdecoder/Jamroot, CreateProbingPT2 is created as a symlink to CreateProbingPT, but this is done in the $(TOP)/bin directory (same for moses_chart BTW). However, $(TOP) refers to the build directory, which may differ from the final install directory, namely when --prefix is used and set to something else than the current directory. In this case, the symlinks are indeed created, but in a directory from which the executables have already been moved out of...

For me, replacing $(TOP) by $(PREFIX) in the last couple of lines of the Jamroot file did the trick both when using --prefix and when not using it, but maybe there is a better way to handle this.