### PR TITLE
fix syntax error; credit: https://patchwork.ozlabs.org/patch/735705/

### DIFF
--- a/scripts/ems/experiment.perl
+++ b/scripts/ems/experiment.perl
@@ -623,7 +623,7 @@ sub find_steps_for_module {
 		print "\t\tneeds input $in: " if $VERBOSE;
 		if(defined($CONFIG{$in}) && $CONFIG{$in}[0] =~ /^\[(.+)\]$/) {
 		    # multiple input, explicitly defined (example: LM:{europarl,nc}:lm )
-		    if ($CONFIG{$in}[0] =~ /^\[([^:]+):{(\S+)}:(\S+)\]$/) {
+		    if ($CONFIG{$in}[0] =~ /^\[([^:]+):[{](\S+)[}]:(\S+)\]$/) {
 			my @SETS = split(',', $2);
 			foreach my $set (@SETS) {
 			    $in = &construct_name($1,$set,$3);


### PR DESCRIPTION
Running experiment.perl on the ems-config as provided by http://www.statmt.org/wmt18/parallel-corpus-filtering.html (with adjustments in the general section), I got an error message about a left curly bracket. This PR changes the regular expression to avoid the error message.

I am not a moses or perl expert. Please review the changes in this PR carefully before accepting.