### PR TITLE
[BLEU] Fix multi-bleu.perl bug (no newline at end of file)

### DIFF
--- a/scripts/generic/multi-bleu.perl
+++ b/scripts/generic/multi-bleu.perl
@@ -48,7 +48,7 @@ sub add_to_ref {
 	open(REF,$file) or die "Can't read $file";
     }
     while(<REF>) {
-	chop;
+	chomp;
 	push @{$$REF[$s++]}, $_;
     }
     close(REF);
@@ -57,7 +57,7 @@ sub add_to_ref {
 my(@CORRECT,@TOTAL,$length_translation,$length_reference);
 my $s=0;
 while(<STDIN>) {
-    chop;
+    chomp;
     $_ = lc if $lowercase;
     my @WORD = split;
     my %REF_NGRAM = ();


### PR DESCRIPTION
When reading hypothesis and reference files, multi-bleu.perl uses the
chop function to remove the trailing newline character.
If one of these files happens to not end with a newline, then chop will
remove the last character of the last line (instead of the newline).
This causes the BLEU score to be slightly off from its theoretical
value.
Using the safest chomp function solves this problem, i.e. it only
removes newlines when present.