### PR TITLE
Add option "-b" (unbuffer output) to tokenizer scripts

### DIFF
--- a/scripts/tokenizer/deescape-special-chars-PTB.perl
+++ b/scripts/tokenizer/deescape-special-chars-PTB.perl
@@ -6,6 +6,11 @@
 use warnings;
 use strict;
 
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 while(<STDIN>) {
   s/\&bar;/\|/g;   # factor separator (legacy)
   s/\&#124;/\|/g;  # factor separator

--- a/scripts/tokenizer/deescape-special-chars.perl
+++ b/scripts/tokenizer/deescape-special-chars.perl
@@ -6,6 +6,11 @@
 use warnings;
 use strict;
 
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 while(<STDIN>) {
   s/\&bar;/\|/g;   # factor separator (legacy)
   s/\&#124;/\|/g;  # factor separator

--- a/scripts/tokenizer/delete-long-words.perl
+++ b/scripts/tokenizer/delete-long-words.perl
@@ -1,6 +1,12 @@
 #!/usr/bin/perl -w
 
 use strict;
+
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 while(<STDIN>) {
   chop;
   my $first = 1;

--- a/scripts/tokenizer/escape-special-chars.perl
+++ b/scripts/tokenizer/escape-special-chars.perl
@@ -6,6 +6,11 @@
 use warnings;
 use strict;
 
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 while(<STDIN>) {
   chop;
 

--- a/scripts/tokenizer/lowercase.perl
+++ b/scripts/tokenizer/lowercase.perl
@@ -6,6 +6,11 @@
 use warnings;
 use strict;
 
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 binmode(STDIN, ":utf8");
 binmode(STDOUT, ":utf8");
 

--- a/scripts/tokenizer/remove-non-printing-char.perl
+++ b/scripts/tokenizer/remove-non-printing-char.perl
@@ -6,6 +6,11 @@
 use warnings;
 use utf8;
 
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 binmode(STDIN, ":utf8");
 binmode(STDOUT, ":utf8");
 binmode(STDERR, ":utf8");

--- a/scripts/tokenizer/replace-unicode-punctuation.perl
+++ b/scripts/tokenizer/replace-unicode-punctuation.perl
@@ -6,6 +6,11 @@
 use warnings;
 use strict;
 
+while (@ARGV) {
+    $_ = shift;
+    /^-b$/ && ($| = 1, next); # not buffered (flush each line)
+}
+
 #binmode(STDIN, ":utf8");
 #binmode(STDOUT, ":utf8");
 


### PR DESCRIPTION
Hello,

I propose to add the optional parameter "-b" to some tokenizer scripts that are currently missing it, comparing to the others which have it (tokenizer.perl, detokenizer.perl, normalize-punctuation.perl, tokenizer_PTB.perl)

This parameter allows to unbuffer the output and it is necessary in the case where you want to chain script calls with pipes in interactive mode.

For instance if you have a bash script (say test.sh) with the following line inside : 
"./normalize-punctuation.perl | ./tokenizer.perl"
And if you want to use it interactively (run ./test.sh), the output will be buffered and therefore not show up at every line, as it would be expected. You have to pass the option "-b" to every perl script to make it interactive:
"./normalize-punctuation.perl **-b** | ./tokenizer.perl **-b**"

Without the option "-b" available, it makes it impossible to use the other scripts (deescape-special-chars.perl, lowercase.perl, etc.) in a shell script in interactive mode.
