### PR TITLE
Patching truecaser

### DIFF
--- a/scripts/recaser/detruecase.perl
+++ b/scripts/recaser/detruecase.perl
@@ -60,19 +60,19 @@ sub process {
     $line =~ s/\s+$//;
     my @WORD  = split(/\s+/,$line);
 
-    # uppercase at sentence start
+    # uppercase first char of word at sentence start
     my $sentence_start = 1;
     for(my $i=0;$i<scalar(@WORD);$i++) {
-      &uppercase(\$WORD[$i]) if $sentence_start;
+      ucfirst(\$WORD[$i]) if $sentence_start;
       if (defined($SENTENCE_END{ $WORD[$i] })) { $sentence_start = 1; }
       elsif (!defined($DELAYED_SENTENCE_START{$WORD[$i] })) { $sentence_start = 0; }
     }
 
-    # uppercase headlines {
+    # uppercase first char of each word in headlines {
     if (defined($SRC) && $HEADLINE[$sentence]) {
 	foreach (@WORD) {
-	    &uppercase(\$_) unless $ALWAYS_LOWER{$_};
-	}	
+	    ucfirst(\$_) unless $ALWAYS_LOWER{$_};
+	}
     }
 
     # output
@@ -84,9 +84,4 @@ sub process {
     }
     print "\n";
     $sentence++;
-}
-
-sub uppercase {
-    my ($W) = @_;
-    $$W = uc(substr($$W,0,1)).substr($$W,1);
 }

--- a/scripts/recaser/train-truecaser.perl
+++ b/scripts/recaser/train-truecaser.perl
@@ -103,8 +103,20 @@ sub split_xml {
   while($line =~ /\S/) {
     # XML tag
     if ($line =~ /^\s*(<\S[^>]*>)(.*)$/) {
-      $MARKUP[$i] .= $1." ";
-      $line = $2;
+      my $potential_xml = $1;
+      my $line_next = $2;
+      # exception for factor that is an XML tag
+      if ($line =~ /^\S/ && scalar(@WORD)>0 && $WORD[$i-1] =~ /\|$/) {
+	$WORD[$i-1] .= $potential_xml;
+	if ($line_next =~ /^(\|+)(.*)$/) {
+	  $WORD[$i-1] .= $1;
+	  $line_next = $2;
+	}
+      }
+      else {
+        $MARKUP[$i] .= $potential_xml." ";
+      }
+      $line = $line_next;
     }
     # non-XML text
     elsif ($line =~ /^\s*([^\s<>]+)(.*)$/) {


### PR DESCRIPTION
The truecaser perl scripts can are improved by

 - standardizing the `split_xml()` function for both training and using (i.e. `train-truecaser.perl` and truecaser.perl`)

 - The default `ucfirst` can capitalize the first character of a string without awkward regexes. Also, comments are corrected for the capitalization of the first character of a string, previously it was stating the function as uppercase without any specification of what it's uppercasing.