### PR TITLE
Use subroutine calls instead

### DIFF
--- a/scripts/recaser/detruecase.perl
+++ b/scripts/recaser/detruecase.perl
@@ -63,7 +63,7 @@ sub process {
     # uppercase first char of word at sentence start
     my $sentence_start = 1;
     for(my $i=0;$i<scalar(@WORD);$i++) {
-      ucfirst(\$WORD[$i]) if $sentence_start;
+      &ucfirst(\$WORD[$i]) if $sentence_start;
       if (defined($SENTENCE_END{ $WORD[$i] })) { $sentence_start = 1; }
       elsif (!defined($DELAYED_SENTENCE_START{$WORD[$i] })) { $sentence_start = 0; }
     }
@@ -71,7 +71,7 @@ sub process {
     # uppercase first char of each word in headlines {
     if (defined($SRC) && $HEADLINE[$sentence]) {
 	foreach (@WORD) {
-	    ucfirst(\$_) unless $ALWAYS_LOWER{$_};
+	    &ucfirst(\$_) unless $ALWAYS_LOWER{$_};
 	}
     }
 


### PR DESCRIPTION
Possibly the calls without the subroutine didn't work with `ucfirst`. Only reason I can think of, otherwise, I think it's safe to just revert all the way back before the patch. 