### PR TITLE
Fix non-ASCII lowercasing

### DIFF
--- a/scripts/generic/multi-bleu-detok.perl
+++ b/scripts/generic/multi-bleu-detok.perl
@@ -14,6 +14,9 @@
 use warnings;
 use strict;
 
+binmode(STDIN, ":utf8");
+use open ':encoding(UTF-8)';
+
 my $lowercase = 0;
 if ($ARGV[0] eq "-lc") {
   $lowercase = 1;


### PR DESCRIPTION
`multi-bleu-detok.perl` -lc does not lowercase non-ASCII characters.

Here's a tiny test case:

```
$ cat ref
ты была непримирима.
но что беспокоит меня, так это то, что...

$ cat hyp
Ты был недоказательным.
Но для меня это то, что
```

Before the change:
```
$ cat hyp | scripts/generic/multi-bleu-detok.perl -lc ref
BLEU = 18.50, 54.5/33.3/28.6/20.0 (BP=0.580, ratio=0.647, hyp_len=11, ref_len=17)
```

After:
```
$ cat hyp | scripts/generic/multi-bleu-detok.perl -lc ref
BLEU = 19.88, 72.7/33.3/28.6/20.0 (BP=0.580, ratio=0.647, hyp_len=11, ref_len=17)
```
