### PR TITLE
escape angle brackets

### DIFF
--- a/scripts/ems/support/wrap-xml.perl
+++ b/scripts/ems/support/wrap-xml.perl
@@ -30,6 +30,8 @@ while(<SRC>) {
     elsif (/<seg/) {
 	my $line = shift(@OUT);
         $line = "" if $line =~ /NO BEST TRANSLATION/;
+	$line =~ s/</&lt;/g;
+	$line =~ s/>/&gt;/g;
         if (/<\/seg>/) {
 	  s/(<seg[^>]+> *).*(<\/seg>)/$1$line$2/i;
           $missing_end_seg = 0;


### PR DESCRIPTION
The script doesn't escape angle brackets which can result in bad SGML / XML output. This fixes that, although ideally, this should be implemented with a proper parser and dumper.