### PR TITLE
Support for Urdu in sentence splitter

### DIFF
--- a/scripts/ems/support/split-sentences.perl
+++ b/scripts/ems/support/split-sentences.perl
@@ -165,6 +165,20 @@ sub preprocess {
         }{$1\n$2}gx;
   }
 
+  # Urdu support
+  # https://en.wikipedia.org/wiki/Urdu_alphabet#Encoding_Urdu_in_Unicode
+  if ($language eq 'ur') {
+    $text =~ s{
+            ( (?: [\.\?!\x{06d4}] | \.\.+ )
+              [\'\"\x{201e}\x{bb}\(\[\¿\¡\p{IsPf}]*
+              )
+            \s+
+            ( [\'\"\x{201e}\x{bb}\(\[\¿\¡\p{IsPi}]*
+              [\x{0600}-\x{06ff}]
+              )
+        }{$1\n$2}gx;
+  }
+
 	# Special punctuation cases are covered. Check all remaining periods.
 	my $word;
 	my $i;


### PR DESCRIPTION
I don't speak Urdu myself. This code is based on the code for Hindi and Gujarati and the information on Urdu Unicode encoding https://en.wikipedia.org/wiki/Urdu_alphabet#Encoding_Urdu_in_Unicode
The code worked fine on visual inspection tested on Urdu text extracted and split from an Urdu web page. The code was used as a step in the production of an English-Urdu corpus.