### PR TITLE
The dot before an acronym should be optional.

### DIFF
--- a/scripts/ems/support/split-sentences.perl
+++ b/scripts/ems/support/split-sentences.perl
@@ -191,7 +191,7 @@ sub preprocess {
 			my $starting_punct = $2;
 			if ($prefix && $NONBREAKING_PREFIX{$prefix} && $NONBREAKING_PREFIX{$prefix} == 1 && !$starting_punct) {
 				# Not breaking;
-			} elsif ($words[$i] =~ /(\.)[\p{IsUpper}\-]+(\.+)$/) {
+			} elsif ($words[$i] =~ /(\.?)[\p{IsUpper}\-]+(\.+)$/) {
 				# Not breaking - upper case acronym
 			} elsif($words[$i+1] =~ /^([ ]*[\'\"\(\[\¿\¡\p{IsPi}]*[ ]*[\p{IsUpper}0-9])/) {
 				# The next word has a bunch of initial quotes, maybe a


### PR DESCRIPTION
Within the non-breaking prefixes when checking for acronyms, it's checking whether:

 1. the first character of an acronym is a dot
 2. the token is made of all caps or dashes
 3. the acronym ends with one or more dots

Criterion (1) for acronymn check is weird, most acronym shouldn't have a dot before and most probably that makes this `elsif` un-used most of the time. 

Instead the pre-caps dot could have been made optional, as proposed in the changes.