### PR TITLE
line buffering for tokeniser and truecaser

### DIFF
--- a/scripts/recaser/detruecase.perl
+++ b/scripts/recaser/detruecase.perl
@@ -83,6 +83,7 @@ sub process {
 	print $_;
     }
     print "\n";
+    STDOUT->flush;
     $sentence++;
 }
 

--- a/scripts/recaser/truecase.perl
+++ b/scripts/recaser/truecase.perl
@@ -82,6 +82,7 @@ while(<STDIN>) {
   }
   print $$MARKUP[$#$MARKUP];
   print "\n";
+  STDOUT->flush
 }
 
 # store away xml markup

--- a/scripts/tokenizer/detokenizer.perl
+++ b/scripts/tokenizer/detokenizer.perl
@@ -64,6 +64,7 @@ while(<STDIN>) {
   } else {
 		print &detokenize($_);
 	}
+	STDOUT->flush
 }
 
 

--- a/scripts/tokenizer/tokenizer.perl
+++ b/scripts/tokenizer/tokenizer.perl
@@ -186,6 +186,7 @@ else
         {
             print &tokenize($_);
         }
+        STDOUT->flush
     }
 }
 


### PR DESCRIPTION
make perl scripts line-buffered (when running in single-threaded mode at least). cf https://github.com/paracrawl/b64filter/issues/1