### PR TITLE
nonbreaking_prefix.tdt: add "Nu" for "Numeru"

### DIFF
--- a/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.tdt
+++ b/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.tdt
@@ -201,7 +201,8 @@ e.g
 # add NUMERIC_ONLY after the word for this function
 #This case is mostly for the english "No." which can either be a sentence of its own, or
 #if followed by a number, a non-breaking prefix
-No #NUMERIC_ONLY# 
+No #NUMERIC_ONLY#
+Nu #NUMERIC_ONLY#
 Nos
 Art #NUMERIC_ONLY#
 Nr


### PR DESCRIPTION
Found a missing nonbreaking prefit for Tetun (tdt).

E.g. "Dekretu-Lei Nu. 18/2022" -> "Decree Law No. 18/2022"