### PR TITLE
Add support for the eflomal aligner

### DIFF
--- a/scripts/ems/experiment.meta
+++ b/scripts/ems/experiment.meta
@@ -680,7 +680,7 @@ process-berkeley
 symmetrize-giza
 	in: giza-alignment giza-alignment-inverse
 	out: word-alignment
-	ignore-if: use-berkeley fast-align-settings
+	ignore-if: use-berkeley fast-align-settings eflomal-settings
 	rerun-on-change: alignment-symmetrization-method training-options script
 	default-name: model/aligned
 	error: skip=<[1-9]

--- a/scripts/ems/experiment.meta
+++ b/scripts/ems/experiment.meta
@@ -626,6 +626,19 @@ symmetrize-fast-align
 	rerun-on-change: alignment-symmetrization-method
 	template: $moses-script-dir/ems/support/symmetrize-fast-align.perl IN IN1 IN2.$input-extension IN2.$output-extension OUT $alignment-symmetrization-method $moses-src-dir/bin/symal
         default-name: model/aligned
+eflomal
+        in: prepared-data-fast-align
+        out: eflomal-alignment
+        rerun-on-change: eflomal-settings
+        template: eflomal-align -i IN $eflomal-settings -f OUT.forward -r OUT.backward 2> OUT.log
+        default-name: eflomal-align
+symmetrize-eflomal
+        in: eflomal-alignment corpus-mml-prefilter=OR=corpus
+        out: word-alignment
+        ignore-unless: eflomal-settings
+        rerun-on-change: alignment-symmetrization-method
+        template: $moses-script-dir/ems/support/symmetrize-fast-align.perl IN.forward IN.backward IN1.$input-extension IN1.$output-extension OUT $alignment-symmetrization-method $moses-src-dir/bin/symal
+        default-name: model/aligned
 prepare-data
 	in: corpus-mml-prefilter=OR=corpus
 	out: prepared-data


### PR DESCRIPTION
This adds basic support for the [eflomal aligner](https://github.com/robertostling/eflomal). Like fast_align, eflomal is enabled by adding eflomal-settings to the config file such as:

```
eflomal-settings = "--model 3"
```