### PR TITLE
fixed path.c in jam-files

### DIFF
--- a/jam-files/engine/modules/path.c
+++ b/jam-files/engine/modules/path.c
@@ -9,6 +9,7 @@
 #include "../lists.h"
 #include "../native.h"
 #include "../timestamp.h"
+#include "../filesys.h"
 
 
 LIST * path_exists( FRAME * frame, int flags )


### PR DESCRIPTION
Jam appears to be broken right now. The `jam-files/engine/modules/path.c` file uses functions defined in `filesys.h` without a proper include. Both a new clang nor a new gcc gave errors during the Jam bootstrap process. This patch fixes the issue.

I don't know much about Jam, so I'm not sure if the more appropriate solution would be to update Jam or complain upstream about this. In any case, this fixes the issue for now.